### PR TITLE
NO-ISSUE: Tasks for VSCode

### DIFF
--- a/src/cim/components/helpers/versions.ts
+++ b/src/cim/components/helpers/versions.ts
@@ -10,7 +10,9 @@ const getVersion = (releaseImage = '') => {
 };
 
 // eslint-disable-next-line
-const getSupportLevelFromChannel = (channel?: string): OpenshiftVersion['supportLevel'] | 'custom' => {
+const getSupportLevelFromChannel = (
+  channel?: string,
+): OpenshiftVersion['supportLevel'] | 'custom' => {
   if (!channel) {
     return 'maintenance';
   }

--- a/src/common/api/swagger.yaml
+++ b/src/common/api/swagger.yaml
@@ -3350,6 +3350,13 @@ paths:
         - userAuth: [admin, read-only-admin, user]
       description: Retrieves the list of infra-envs.
       operationId: ListInfraEnvs
+      parameters:
+        - in: query
+          name: cluster_id
+          description: If provided, returns only infra-envs which directly reference this cluster.
+          type: string
+          format: uuid
+          required: false
       responses:
         '200':
           description: Success.
@@ -7966,7 +7973,7 @@ definitions:
       ca_certificate:
         type: string
         x-nullable: true
-        description: A CA certficate to be used when contacting the URL via https.
+        description: base64 encoded CA certficate to be used when contacting the URL via https.
 
   platform:
     type: object
@@ -8209,6 +8216,9 @@ definitions:
         type: string
         description:
           JSON-formatted string containing additional information regarding tang's configuration
+        example:
+          '[{"url":"http://tang.example.com:7500","thumbprint":"PLjNyRdGw03zlRoGjQYMahSZGu9"},
+          {"url":"http://tang.example.com:7501","thumbprint":"PLjNyRdGw03zlRoGjQYMahSZGu8"}]'
         x-go-custom-tag: gorm:"type:text"
 
   host-stage:
@@ -8568,6 +8578,9 @@ definitions:
       is_success:
         type: boolean
         description: API VIP connectivity check result.
+      ignition:
+        type: string
+        description: Ignition fetched from the specified API VIP
 
   disk_speed_check_request:
     type: object
@@ -9186,6 +9199,7 @@ definitions:
         type: string
         format: uuid
         description: If set, all hosts that register will be associated with the specified cluster.
+        x-go-custom-tag: gorm:"index"
       size_bytes:
         type: integer
         minimum: 0

--- a/src/common/api/types.ts
+++ b/src/common/api/types.ts
@@ -39,6 +39,10 @@ export interface ApiVipConnectivityResponse {
    * API VIP connectivity check result.
    */
   isSuccess?: boolean;
+  /**
+   * Ignition fetched from the specified API VIP
+   */
+  ignition?: string;
 }
 export interface AssistedServiceIsoCreateParams {
   /**
@@ -855,6 +859,8 @@ export interface DiskEncryption {
   mode?: 'tpmv2' | 'tang';
   /**
    * JSON-formatted string containing additional information regarding tang's configuration
+   * example:
+   * [{"url":"http://tang.example.com:7500","thumbprint":"PLjNyRdGw03zlRoGjQYMahSZGu9"}, {"url":"http://tang.example.com:7501","thumbprint":"PLjNyRdGw03zlRoGjQYMahSZGu8"}]
    */
   tangServers?: string;
 }
@@ -1427,7 +1433,7 @@ export interface IgnitionEndpoint {
    */
   url?: string;
   /**
-   * A CA certficate to be used when contacting the URL via https.
+   * base64 encoded CA certficate to be used when contacting the URL via https.
    */
   caCertificate?: string;
 }
@@ -2267,6 +2273,9 @@ export interface V2Events {
   hostId?: string;
   infraEnvId?: string;
   categories?: string[];
+}
+export interface V2InfraEnvs {
+  clusterId?: string;
 }
 export interface VersionedHostRequirements {
   /**

--- a/src/ocm/services/apis/InfraEnvsAPI.ts
+++ b/src/ocm/services/apis/InfraEnvsAPI.ts
@@ -7,8 +7,13 @@ const InfraEnvsAPI = {
     return `/v2/infra-envs/${infraEnvId ? infraEnvId : ''}`;
   },
 
-  list() {
-    return client.get<InfraEnv[]>(`${InfraEnvsAPI.makeBaseURI()}`);
+  /**
+   * Retrieves the list of infra-envs.
+   * @param clusterId If provided, returns only infra-envs which directly reference the given clusterId.
+   */
+  list(clusterId = '') {
+    const query = clusterId && `?${new URLSearchParams({ ['cluster_id']: clusterId })}`;
+    return client.get<InfraEnv[]>(`${InfraEnvsAPI.makeBaseURI()}${query}`);
   },
 
   get(infraEnvId: InfraEnv['id']) {


### PR DESCRIPTION
Some tasks related to OCM development that enable launching 3 terminals with the `start`, `sync-dist` and `start:assisted-ui` or `start:uhc-portal` target from one command